### PR TITLE
fix server-specific discord avatar URL

### DIFF
--- a/pkg/platforms/discord/incoming.go
+++ b/pkg/platforms/discord/incoming.go
@@ -96,6 +96,10 @@ func getLightningAuthor(s *discordgo.Session, m *discordgo.Message) lightning.Me
 		}
 	}
 
+	if m.Member.GuildID == "" {
+		m.Member.GuildID = m.GuildID
+	}
+
 	m.Member.User = m.Author
 	author.Nickname = m.Member.DisplayName()
 	profilePicture = m.Member.AvatarURL("")


### PR DESCRIPTION
discordgo does not seem to fill all member fields correctly in the message object passed to the Discord message listener. Fill them in manually in those cases. (fix #89)